### PR TITLE
fix #322

### DIFF
--- a/controller/IndexController.php
+++ b/controller/IndexController.php
@@ -48,7 +48,7 @@ class IndexController{
 		list($password) = explode("\n",$password);
 		$password = trim($password);
 		unset($this->items['.password']);
-		if(!empty($password) && $password == $_COOKIE[md5($this->path)]){
+		if(!empty($password) && strcmp($password, $_COOKIE[md5($this->path)]) === 0){
 			return true;
 		}
 
@@ -57,7 +57,7 @@ class IndexController{
 	}
 
 	function password($password){
-		if(!empty($_POST['password']) && $password == $_POST['password']){
+		if(!empty($_POST['password']) && strcmp($password, $_POST['password']) === 0){
 			setcookie(md5($this->path), $_POST['password']);
 			return true;
 		}


### PR DESCRIPTION
php的`==`在两边字符串都是数字格式时会转为数字比较，所以
```php
var_dump('1234', '1234.'); //true
```

改成使用`strcmp`强制作为字符串比较。
p.s. 尽管这样依然可以通过判断响应时间来爆破密码，但是在现在的场景下应该够用了。吧。。。