### PR TITLE
Use GET Method in file list

### DIFF
--- a/view/material/list.php
+++ b/view/material/list.php
@@ -114,7 +114,7 @@ $.fn.extend({
 $(function () {
     $('.file a').each(function () {
         $(this).on('click', function () {
-            var form = $('<form target=_blank method=post></form>').attr('action', $(this).attr('href')).get(0);
+            var form = $('<form target=_blank method=get><input type="hidden" name="s" value="show"></form>').attr('action', $(this).attr('href')).get(0);
             $(document.body).append(form);
             form.submit();
             $(form).remove();


### PR DESCRIPTION
用 POST 的话不方便分享文件展示页面（播放器之类的很需要直接展示），而且刷新的时候会弹框提示重复提交。实际上是有一个 s 参数检测逻辑实现用 GET 访问展示的，所以不如对列表直接使用这个 s 参数以 GET 方法请求。