### PR TITLE
新增适用于Debian和Ubuntu的安装脚本。

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Onedrive Directory Index
 ## 配置：
 <img width="658" alt="image" src="https://raw.githubusercontent.com/donwa/oneindex/files/images/install.gif">  
 
+### 使用脚本文件安装：
+
+此脚本仅适用于Ubuntu和Debian系统。请使用root用户运行：
+
+```sh
+wget http://oss.zihangu.com/install.sh
+chmod u+x install.sh
+./install.sh
+```
 
 ### Docker 安装运行：
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ apt-get install php7.2 -y
 apt-get install php7.2-fpm php7.2-curl php7.2-json php7.2-mbstring php7.2-xml  php7.2-intl -y
 cd /var/www/
 git clone https://github.com/donwa/oneindex.git
-rm -rf /var/www/html/*
+rm -rf /var/www/html/
 mv oneindex html
 service restart apache2
 echo "安装完成。请前往 http://[IP]/ 进行程序初始化。"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,9 @@ LANG=en_US.UTF-8
 
 echo "OneIndex 安装脚本，By TheZihanGu"
 echo "OneIndex 将安装在 /var/www/html"
-echo "此脚本仅适用于Ubuntu和Debian系统."
+echo "此脚本仅适用于Ubuntu和Debian系统。"
+echo "将会自动安装Apache2和PHP7.2运行环境，请保证系统无安装其他Web服务端。"
+echo "[警告]将会清空/var/www/html文件夹!"
 echo "[必须]请使用root用户执行此脚本."
 echo "项目页面：https://github.com/donwa/oneindex"
 echo "Feedback：请到Issues反馈。"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:~/bin
+export PATH
+LANG=en_US.UTF-8
+
+echo "OneIndex 安装脚本，By TheZihanGu"
+echo "OneIndex 将安装在 /var/www/html"
+echo "此脚本仅适用于Ubuntu和Debian系统."
+echo "[必须]请使用root用户执行此脚本."
+echo "项目页面：https://github.com/donwa/oneindex"
+echo "Feedback：请到Issues反馈。"
+echo "请按任意键开始安装，或者Ctrl+C来取消安装."
+read
+echo "开始安装..."
+ln -sf bash /bin/sh
+apt-get update -y
+apt-get upgrade -y
+apt-get install apache2 -y
+apt-get install git -y
+apt-get install unzip -y
+apt-get install php7.2 -y
+apt-get install php7.2-fpm php7.2-curl php7.2-json php7.2-mbstring php7.2-xml  php7.2-intl -y
+cd /var/www/
+git clone https://github.com/donwa/oneindex.git
+rm -rf /var/www/html/*
+mv oneindex html
+service restart apache2
+echo "安装完成。请前往 http://[IP]/ 进行程序初始化。"


### PR DESCRIPTION
关于安装脚本：
脚本会进行以下操作：
1.自动安装Apache2及PHP7.2。
2.Clone https://github.com/donwa/oneindex.git
3.做最后的准备工作。
本脚本仅在Debian和Ubuntu测试通过。使用阿里云OSS进行install.sh文件存放。
关于README.md：
新增关于脚本安装的有关内容。