### PR TITLE
修复nexmoe主题下加载flv视频可能失败的bug

### DIFF
--- a/view/nexmoe/show/video.php
+++ b/view/nexmoe/show/video.php
@@ -27,7 +27,7 @@ const dp = new DPlayer({
 	video: {
 	    url: '<?php e($item['downloadUrl']);?>',
 	    pic: '<?php @e($item['thumb']);?>',
-	    type: 'auto'
+	    type: '<?php e((pathinfo($item["name"], PATHINFO_EXTENSION) === 'flv') ? 'flv' : 'auto'); ?>'
 	}
 });
 </script>


### PR DESCRIPTION
如题，在自建云空间时发现使用nexmoe主题无法播放flv格式视频，与其他主题对照发现该处不同，尝试修改后视频可以正常播放。